### PR TITLE
fixed params update

### DIFF
--- a/grounding/test.py
+++ b/grounding/test.py
@@ -358,7 +358,8 @@ if __name__ == '__main__':
     cfgs_file = os.path.join('cfgs',cfgs_file)
     with open(cfgs_file, 'r') as handle:
         options_yaml = yaml.load(handle, Loader=yaml.FullLoader)
-    update_values(options_yaml, params)
+    # update_values(options_yaml, params)
+    update_values(params, options_yaml)
     # print(params)
 
 

--- a/grounding/train.py
+++ b/grounding/train.py
@@ -580,7 +580,8 @@ if __name__ == '__main__':
     cfgs_file = os.path.join('cfgs',cfgs_file)
     with open(cfgs_file, 'r') as handle:
         options_yaml = yaml.load(handle, Loader=yaml.FullLoader)
-    update_values(options_yaml, params)
+    # update_values(options_yaml, params)
+    update_values(params, options_yaml)
     # print(params)
 
 


### PR DESCRIPTION
I tried to give argument like
'''
--train_data ../Charades 
'''
when running python file, but cfg file overwrites params file as the params in update_values are reversed

so I modified the params order in update_values